### PR TITLE
🐛 : rubocopのワークフローが正しく動いていなかったため、修正した

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -15,12 +15,3 @@ jobs:
         run: bundle install
       - name: Run Rubocop
         run: bundle exec rubocop
-
-Style/Documentation:
-  Enabled: false
-Style/FrozenStringLiteralComment:
-  Enabled: false
-Style/StringLiterals:
-  Enabled: false
-Bundler/OrderedGems:
-  Enabled: false


### PR DESCRIPTION
- [x] rubocopのワークフローが動いていなかったため、修正した。